### PR TITLE
Remove the #define when no coroutine support

### DIFF
--- a/Source/EnhancedCodeFlow/Public/Coroutines/ECFCoroutine.h
+++ b/Source/EnhancedCodeFlow/Public/Coroutines/ECFCoroutine.h
@@ -40,8 +40,6 @@ struct FECFCoroutinePromise
 
 #include "ECFHandle.h"
 
-#define ECF_WITH_COROUTINES 0
-
 using FECFCoroutine = void;
 
 struct FECFCoroutinePromise


### PR DESCRIPTION
Using #define with 0 will still be detected as a defined variable and cannot be used with #ifdef but require #if + TEST